### PR TITLE
Insert video thumbnail on non-website platforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ module.exports = {
         youtube: {
             process: function(blk) {
                 var videoId = getYouTubeID(blk.body) || blk.body;
-                var url = "http://www.youtube.com/watch?v="+videoId;
-                var videoThumb = 'http://img.youtube.com/vi/'+videoID+'0.jpg' /* 0.jpg is default full resolution image. 1–3.jpg is thumbnails */
+                var url = "//www.youtube.com/watch?v="+videoId;
+                var videoThumb = '//img.youtube.com/vi/'+videoID+'0.jpg' /* 0.jpg is default full resolution image. 1–3.jpg is thumbnails */
 
                 if (this.generator != "website") {
                     return '<a href="'+url+'"><img src="'+videoThumb+'" alt="YouTube video thumbnail">'+url+'</img></a>';

--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@ module.exports = {
             process: function(blk) {
                 var videoId = getYouTubeID(blk.body) || blk.body;
                 var url = "http://www.youtube.com/watch?v="+videoId;
+                var videoThumb = 'http://img.youtube.com/vi/'+videoID+'0.jpg' /* 0.jpg is default full resolution image. 1–3.jpg is thumbnails */
 
                 if (this.generator != "website") {
-                    return '<a href="'+url+'">'+url+'</a>';
+                    return '<a href="'+url+'"><img src="'+videoThumb+'" alt="YouTube video thumbnail">'+url+'</img></a>';
                 }
 
                 return '<div style="position: relative;padding-bottom: 56.25%;padding-top: 25px;height: 0;">'

--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ module.exports = {
         youtube: {
             process: function(blk) {
                 var videoId = getYouTubeID(blk.body) || blk.body;
-                var url = "//www.youtube.com/watch?v="+videoId;
-                var videoThumb = '//img.youtube.com/vi/'+videoID+'0.jpg' /* 0.jpg is default full resolution image. 1–3.jpg is thumbnails */
+                var url = "http://youtube.com/watch?v="+videoId;
+                var videoThumb = 'http://img.youtube.com/vi/'+videoId+'/0.jpg' /* 0.jpg is default full resolution image. 1–3.jpg is thumbnails */
 
                 if (this.generator != "website") {
-                    return '<a href="'+url+'"><img src="'+videoThumb+'" alt="YouTube video thumbnail">'+url+'</img></a>';
+                    return '<a href="'+url+'"><img src="'+videoThumb+'" alt="YouTube video thumbnail" /></a>';
                 }
 
                 return '<div style="position: relative;padding-bottom: 56.25%;padding-top: 25px;height: 0;">'

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
                 var videoThumb = 'http://img.youtube.com/vi/'+videoId+'/0.jpg' /* 0.jpg is default full resolution image. 1–3.jpg is thumbnails */
 
                 if (this.generator != "website") {
-                    return '<a href="'+url+'"><img src="'+videoThumb+'" alt="YouTube video thumbnail" /></a>';
+                    return '<img src="'+videoThumb+'" alt="YouTube video thumbnail" /><p><a href="'+url+'">Video link</p></a>';
                 }
 
                 return '<div style="position: relative;padding-bottom: 56.25%;padding-top: 25px;height: 0;">'


### PR DESCRIPTION
Made a small change to take and output the video thumbnail on non-website gitbooks (e.g. epub, pdf). On a later stage I'll add the possibilty of changing the link text and/or thumbnail styling options.
