### PR TITLE
Fixed misordered closing tags for non-website link

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
                 var videoThumb = 'http://img.youtube.com/vi/'+videoId+'/0.jpg' /* 0.jpg is default full resolution image. 1–3.jpg is thumbnails */
 
                 if (this.generator != "website") {
-                    return '<img src="'+videoThumb+'" alt="YouTube video thumbnail" /><p><a href="'+url+'">Video link</p></a>';
+                    return '<img src="'+videoThumb+'" alt="YouTube video thumbnail" /><p><a href="'+url+'">Video link</a></p>';
                 }
 
                 return '<div style="position: relative;padding-bottom: 56.25%;padding-top: 25px;height: 0;">'


### PR DESCRIPTION
The closing `</p>` and `</a>` tags for the non-website generator were resulting in invalid HTML and needed to be reversed.
