### PR TITLE
Fix for offline builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
                 }
 
                 return '<div style="position: relative;padding-bottom: 56.25%;padding-top: 25px;height: 0;">'
-                +'<iframe frameborder="0" allowfullscreen style="border: none;position: absolute;top: 0;left: 0;width: 100%;height: 100%;" src="//www.youtube.com/embed/'+videoId+'"></iframe>'
+                +'<iframe frameborder="0" allowfullscreen style="border: none;position: absolute;top: 0;left: 0;width: 100%;height: 100%;" src="https://www.youtube.com/embed/'+videoId+'"></iframe>'
                 +'</div>';
             }
         }


### PR DESCRIPTION
Added `https` because if you are running gitbook build offline, `//` resolves as `file://` and not as http protocol.
